### PR TITLE
1.3 dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "tijsverkoyen/convert-to-junit-xml": "^1.6",
         "beberlei/doctrineextensions": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^2.0",
-        "sentry/sentry-symfony": "^3.1",
+        "sentry/sentry-symfony": "^3.1"
     },
     "require-dev": {
         "mglaman/phpstan-junit": "^0.12",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "phpstan/phpstan-symfony": "^0.12.4",
         "sensiolabs/security-checker": "^6.0",
         "squizlabs/php_codesniffer": "^3.4",
-        "tijsverkoyen/deployer-sumo": "^1.4"
+        "tijsverkoyen/deployer-sumo": "^1.4",
+        "symfony/debug-pack": "*"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -7,28 +7,22 @@
         "php": "^7.2",
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "symfony/flex": "^1.6.2",
+        "symfony/website-skeleton": "^5.0",
+        "symfony/apache-pack": "^1.0.1",
+        "symfony/webpack-encore-bundle": "^1.6.2",
+        "sumocoders/framework-core-bundle": "dev-symfony-5",
+        "tijsverkoyen/convert-to-junit-xml": "^1.6",
         "beberlei/doctrineextensions": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^2.0",
-        "sentry/sentry-symfony": "^3.1",
-        "sumocoders/framework-core-bundle": "^1.0",
-        "symfony/apache-pack": "^1.0.1",
-        "symfony/dotenv": "^4.4",
-        "symfony/flex": "^1.4.5",
-        "symfony/webpack-encore-bundle": "^1.6.2",
-        "symfony/website-skeleton": "^4.4",
-        "symfony/yaml": "^4.4",
-        "tijsverkoyen/convert-to-junit-xml": "^1.3",
-        "symfony/security-bundle": "^4.4"
+        "sentry/sentry-symfony": "^3.1"
     },
     "require-dev": {
-        "mglaman/phpstan-junit": "^0.11.2",
-        "phpstan/phpstan-symfony": "^0.11.6",
+        "mglaman/phpstan-junit": "^0.12",
+        "phpstan/phpstan-symfony": "^0.12.4",
         "sensiolabs/security-checker": "^6.0",
         "squizlabs/php_codesniffer": "^3.4",
-        "symfony/debug-pack": "*",
-        "symfony/profiler-pack": "*",
-        "symfony/test-pack": "*",
-        "tijsverkoyen/deployer-sumo": "^1.1"
+        "tijsverkoyen/deployer-sumo": "^1.4"
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,14 @@
         "ext-iconv": "*",
         "symfony/flex": "^1.6.2",
         "symfony/website-skeleton": "^5.0",
+        "symfony/security-bundle": "^5.0",
         "symfony/apache-pack": "^1.0.1",
         "symfony/webpack-encore-bundle": "^1.6.2",
         "sumocoders/framework-core-bundle": "dev-symfony-5",
         "tijsverkoyen/convert-to-junit-xml": "^1.6",
         "beberlei/doctrineextensions": "^1.2",
         "doctrine/doctrine-migrations-bundle": "^2.0",
-        "sentry/sentry-symfony": "^3.1"
+        "sentry/sentry-symfony": "^3.1",
     },
     "require-dev": {
         "mglaman/phpstan-junit": "^0.12",

--- a/scripts/post-update-cmd.php
+++ b/scripts/post-update-cmd.php
@@ -47,25 +47,29 @@ function addParameters(): void
     fclose($handle);
 }
 
-function addJMSi18nParameters(): void
+function addDefaulti18nPrefixes(): void
 {
-    echo "Adding JMS i18n parameters to services.yaml\n";
+    echo "Adding i18n prefixes to annotations.yaml\n";
     $filePath =
         __DIR__ . DIRECTORY_SEPARATOR .
         '..' . DIRECTORY_SEPARATOR .
         'config' . DIRECTORY_SEPARATOR .
-        'packages' . DIRECTORY_SEPARATOR .
-        'translation.yaml';
+        'routes' . DIRECTORY_SEPARATOR .
+        'annotations.yaml';
     $lines = [
+        "controllers:\n",
+        "   resource: ../../src/Controller/\n",
+        "   type: annotation\n",
+        "   prefix:\n",
+        "       '%locale%': '%locale%'\n",
         "\n",
-        "jms_i18n_routing:\n",
-        "    default_locale: '%locale%'\n",
-        "    locales: '%locales%'\n",
-        "    strategy: prefix_except_default\n",
-        "\n",
+        "kernel:\n",
+        "   resource: ../../src/Kernel.php\n",
+        "   type: annotation\n",
+        "\n"
     ];
 
-    $handle = fopen($filePath, 'a');
+    $handle = fopen($filePath, 'w');
     if ($handle === false) {
         echo "File $filePath cannot be opened to read/write\n";
         exit(2);
@@ -79,7 +83,7 @@ function addJMSi18nParameters(): void
 }
 
 addParameters();
-addJMSi18nParameters();
+addDefaulti18nPrefixes();
 
 echo "Removing post-update-cmd from composer.json\n";
 exec(


### PR DESCRIPTION
Replace the old JMS i18n bundle config that is generated during the post install script + update our dependencies so we can move on to v5.0.4 for most Symfony components.