### PR TITLE
Remove redundant bootstrap import

### DIFF
--- a/scripts/assets/app.scss
+++ b/scripts/assets/app.scss
@@ -1,3 +1,1 @@
-@import '~bootstrap/scss/functions';
-@import '~bootstrap/scss/variables';
 @import '~frameworkstylepackage/src/sass/style';


### PR DESCRIPTION
These files are already imported in our style package, so they're
redundant here.

if I'm wrong about this feel free to tell me. The file that we import through the skeleton is this one: https://github.com/sumocoders/FrameworkStylePackage/blob/master/src/sass/style.scss, which in turns references the bootstrap variables and functions.