### PR TITLE
Improve jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ Check code standards with PHP_CodeSniffer:
   image: sumocoders/framework-php72:latest
   before_script:
     - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
+    - php -d memory_limit=-1 composer.phar install --no-scripts
   script:
     - vendor/bin/phpcs --report-full --report-junit=phpcs-report.xml
   artifacts:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,8 +30,10 @@ Check for bugs with PHPStan:
     - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
     - bin/console cache:warmup --env=dev
   script:
-    - vendor/bin/phpstan analyse --memory-limit=-1
     - vendor/bin/phpstan analyse --memory-limit=-1 --error-format=junit --no-progress > phpstan-report.xml
+  after_script:
+    # Run it again so the output is visible in the job
+    - vendor/bin/phpstan analyse --memory-limit=-1
   artifacts:
     expire_in: 1 week
     reports:
@@ -47,8 +49,10 @@ Check for unresolved TODOs:
     - curl -sS https://getcomposer.org/installer | php
     - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
-    - grep --exclude-dir={bin,node_modules,var,vendor} -rni -E "\b(FIXME|TODO|HACK|REVIEW|QUESTION|TEMP)\b" *
     - vendor/bin/convert-to-junit-xml convert:grep "$(grep --exclude-dir={bin,node_modules,var,vendor} -rni -E "\b(FIXME|TODO|HACK|REVIEW|QUESTION|TEMP)\b" *)" > unresolved-todos-report.xml
+  after_script:
+    # Run it again so the output is visible in the job
+    - grep --exclude-dir={bin,node_modules,var,vendor} -rni -E "\b(FIXME|TODO|HACK|REVIEW|QUESTION|TEMP)\b" *
   artifacts:
     expire_in: 1 week
     reports:
@@ -67,6 +71,9 @@ Check NPM dependencies for vulnerabilities:
     - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
     - vendor/bin/convert-to-junit-xml convert:npm-audit "$(npm audit --json)" > npm-audit-report.xml
+  after_script:
+    # Run it again so the output is visible in the job output
+    - npm audit --json
   artifacts:
     expire_in: 1 week
     reports:
@@ -83,6 +90,9 @@ Check Composer dependencies for vulnerabilities:
     - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
     - vendor/bin/convert-to-junit-xml convert:sensiolabs-security-check "$(vendor/bin/security-checker security:check --format=json)" > security-checker-report.xml
+  after_script:
+    # Run it again so the output is visible in the job output
+    - vendor/bin/security-checker security:check
   artifacts:
     expire_in: 1 week
     reports:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,17 +1,28 @@
 stages:
+  - optimalisation
   - code quality
   - dependency scanning
   - build
   - test
   - deploy
 
+cache:
+  paths:
+    - vendor
+    - node_modules
+
+# Optimalisation
+Install composer dependencies:
+  image: sumocoders/framework-php72:latest
+  script:
+    - COMPOSER_MEMORY_LIMIT=-1 composer install --no-scripts
+  stage: optimalisation
+  tags:
+    - docker
 
 # Code Quality section
 Check code standards with PHP_CodeSniffer:
   image: sumocoders/framework-php72:latest
-  before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts
   script:
     - vendor/bin/phpcs --report-full --report-junit=phpcs-report.xml
   artifacts:
@@ -26,8 +37,6 @@ Check code standards with PHP_CodeSniffer:
 Check for bugs with PHPStan:
   image: sumocoders/framework-php72:latest
   before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
     - bin/console cache:warmup --env=dev
   script:
     - vendor/bin/phpstan analyse --memory-limit=-1 --error-format=junit --no-progress > phpstan-report.xml
@@ -45,9 +54,6 @@ Check for bugs with PHPStan:
 
 Check for unresolved TODOs:
   image: sumocoders/cli-tools-php72
-  before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
     - vendor/bin/convert-to-junit-xml convert:grep "$(grep --exclude-dir={bin,node_modules,var,vendor} -rni -E "\b(FIXME|TODO|HACK|REVIEW|QUESTION|TEMP)\b" *)" > unresolved-todos-report.xml
   after_script:
@@ -66,14 +72,11 @@ Check for unresolved TODOs:
 ## Dependency Scanning section
 Check NPM dependencies for vulnerabilities:
   image: sumocoders/cli-tools-php72:latest
-  before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
-    - vendor/bin/convert-to-junit-xml convert:npm-audit "$(npm audit --json)" > npm-audit-report.xml
+    - vendor/bin/convert-to-junit-xml convert:npm-audit "$(nvm exec npm audit --json)" > npm-audit-report.xml
   after_script:
     # Run it again so the output is visible in the job output
-    - npm audit --json
+    - nvm exec npm audit --json
   artifacts:
     expire_in: 1 week
     reports:
@@ -85,9 +88,6 @@ Check NPM dependencies for vulnerabilities:
 
 Check Composer dependencies for vulnerabilities:
   image: sumocoders/cli-tools-php72:latest
-  before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
     - vendor/bin/convert-to-junit-xml convert:sensiolabs-security-check "$(vendor/bin/security-checker security:check --format=json)" > security-checker-report.xml
   after_script:
@@ -122,9 +122,6 @@ Build assets with Encore:
 ## Test section
 Run test with PHPUnit:
   image: sumocoders/framework-php72:latest
-  before_script:
-    - curl -sS https://getcomposer.org/installer | php
-    - php -d memory_limit=-1 composer.phar install --no-scripts --quiet --ignore-platform-reqs
   script:
     - vendor/bin/simple-phpunit --log-junit phpunit-report.xml
   artifacts:
@@ -151,11 +148,6 @@ Run test with PHPUnit:
 #    - chmod 700 ~/.ssh
 #    - echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 #    - chmod 644 ~/.ssh/known_hosts
-#    # Install composer binary and install the vendors
-#    - curl -sS https://getcomposer.org/installer | php
-#    - php composer.phar install --no-scripts --quiet --ignore-platform-reqs
-#    # Install NPM dependencies
-#    - npm install
 #  script:
 #    - vendor/bin/dep deploy staging
 #  environment:


### PR DESCRIPTION
This should improve the total time needed for running the pipeline.

The composer packages are now install before everything else and cached, so no need to install them again and again in each job.

Also our images have composer installed, so there is no need to install composer ourself in a job.