### PR TITLE
Fix issue with js translation bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/website-skeleton": "^5.0",
         "symfony/yaml": "^5.0",
         "tijsverkoyen/convert-to-junit-xml": "^1.7",
-        "willdurand/js-translation-bundle": "^3.0"
+        "willdurand/js-translation-bundle": "^4.0"
     },
     "require-dev": {
         "mglaman/phpstan-junit": "^0.12",

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -236,7 +236,7 @@ class PostCreateProject
             '.addPlugin(',
             '  new WebpackShellPlugin({',
             '    onBuildStart: [',
-            '      \'bin/console bazinga:js-translation:dump public/build --format=json --merge-domains\',',
+            '      //\'bin/console bazinga:js-translation:dump public/build --format=json --merge-domains\',',
             '      \'bin/console fos:js-routing:dump --format=json --locale=nl --target=public/build/routes/fos_js_routes.json\'',
             '    ],',
             '  })',


### PR DESCRIPTION
It seems like JsTranslationBundle v3 is not compatible with Symfony 5, so bumped it to v4

Alos, when running the command something fails while running `bin/console bazinga:js-translation:dump public/build --format=json --merge-domains`, so I commented it for now.

Should fix: https://app.activecollab.com/108877/projects/533/tasks/95254