### PR TITLE
Ignore generated files when running stylelint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,6 +1,9 @@
+assets/images/*.svg
 bin/*
 config/*
+public/build/*
 public/bundles/*
+public/files/*
 node_modules/*
 var/*
 vendor/*


### PR DESCRIPTION
The generated files, svg's are mostly files we don't control, so there is no
use to check them.