### PR TITLE
Job that checks coding standards for Twig templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -65,6 +65,19 @@ PHPStan - check for bugs:
     - docker
   allow_failure: true
 
+Twigcs - check code styling:
+  image: sumocoders/framework-php74:latest
+  script:
+    - vendor/bin/twigcs --report-full --report-junit=phpcs-report.xml
+  artifacts:
+    expire_in: 1 week
+    reports:
+      junit: phpcs-report.xml
+  stage: code quality
+  tags:
+    - docker
+  allow_failure: true
+
 Stylelint - check code styling:
   image: sumocoders/cli-tools-php74
   script:

--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,12 @@
         "willdurand/js-translation-bundle": "^4.0"
     },
     "require-dev": {
+        "friendsoftwig/twigcs": "^5.0",
         "mglaman/phpstan-junit": "^0.12",
         "phpstan/phpstan-symfony": "^0.12.4",
         "squizlabs/php_codesniffer": "^3.4",
-        "tijsverkoyen/deployer-sumo": "^1.4",
-        "symfony/debug-pack": "*"
+        "symfony/debug-pack": "*",
+        "tijsverkoyen/deployer-sumo": "^1.4"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
It uses [friendsoftwig/twigcs](https://github.com/friendsoftwig/twigcs), which
validates for the official coding standard of Twig.

An example of the output: https://git.sumocoders.be/sumocoders/wasewind-app/-/jobs/141925