### PR TITLE
Ignore common Sentry errors

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -426,6 +426,20 @@ class PostCreateProject
         );
         file_put_contents($projectDir . '/config/packages/framework.yaml', $content);
 
+        $io->notice('→ Reconfigure sentry');
+        $content = file_get_contents($projectDir . '/config/packages/sentry.yaml');
+        $insert = [
+            '    options:',
+            '        excluded_exceptions:',
+            '            - \'Symfony\Component\HttpKernel\Exception\NotFoundHttpException\'',
+            '            - \'Symfony\Component\Security\Core\Exception\AccessDeniedException\'',
+        ];
+        $content = self::insertStringAtPosition(
+            $content,
+            mb_strlen($content) + 1,
+            implode("\n", $insert) . "\n"
+        );
+        file_put_contents($projectDir . '/config/packages/sentry.yaml', $content);
 
         $io->notice('→ Reconfigure .env');
         $content = file_get_contents($projectDir . '/.env');


### PR DESCRIPTION
Symfony listens for these errors using the kernel.exception event and handles them accordingly
(redirect to login, show 404, etc..) but even when handled, they still get thrown so Sentry
logs them. This ends up flooding our Sentry logs with errors that don't mean anything.