### PR TITLE
Register a Twig path for our public folder by default.

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -346,6 +346,8 @@ class PostCreateProject
             '        - "bootstrap_4_layout.html.twig"',
             '        - "@SumoCodersFrameworkCore/Form/fields.html.twig"',
             '        - "blocks.html.twig"',
+            '    paths:',
+            '        \'%kernel.project_dir%/public/\': public',
         ];
         $content = self::insertStringAtPosition(
             $content,


### PR DESCRIPTION
This will be used by the inline_css filter to locate the built version of our mail.css file. We have to read this file using the Twig source() function, which by default only reads from the default Twig path: /templates.

Usually source() is only intended for loading templates, as the asset() and webpack_encore_link_tag() methods exist to load stylesheets inside templates, but since both email clients and the inline_css extension don't actually resolve stylesheet URLs, we need to use this hack-y method to get the raw content of the CSS file and pass it to the inline_css extension manually.