### PR TITLE
Update the twig configuration with the new 5.3 added test config

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -339,6 +339,9 @@ class PostCreateProject
 
         $io->notice('→ Reconfigure Twig');
         $content = file_get_contents($projectDir . '/config/packages/twig.yaml');
+        $matches = [];
+        preg_match('|twig:|smU', $content, $matches, PREG_OFFSET_CAPTURE);
+        $offset = $matches[0][1] + mb_strlen($matches[0][0]);
         $insert = [
             '    globals:',
             '        fallbacks: "@framework.fallbacks"',
@@ -351,13 +354,13 @@ class PostCreateProject
             '        - "@SumoCodersFrameworkCore/Form/fields.html.twig"',
             '        - "blocks.html.twig"',
             '    paths:',
-            '        # We add our public folder to the default twig path so we can load the',
-            '        # mail stylesheet into the inline_css inside the base email template.',
+            '        # Add the public folder to the default twig path so we can access the',
+            '        # mail stylesheet through the inline_css method in the base email template.',
             '        \'%kernel.project_dir%/public/\': ~',
         ];
         $content = self::insertStringAtPosition(
             $content,
-            mb_strlen($content) + 1,
+            $offset,
             implode("\n", $insert) . "\n"
         );
         file_put_contents($projectDir . '/config/packages/twig.yaml', $content);


### PR DESCRIPTION
The default twig.yaml config used to be:
```
twig:
    default_path: '%kernel.project_dir%/templates'
```
which meant we could just append our changes to the end of the file. But after 5.3 (or with the new Panther test suite), it's:
```
twig:
    default_path: '%kernel.project_dir%/templates'

when@test:
    twig:
        strict_variables: true
```
which breaks the current set-up. This PR inserts our changes on the next line after `twig:`, which produces a valid yaml config file.