### PR TITLE
Fix twig.yaml

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -366,7 +366,7 @@ class PostCreateProject
         $content = self::insertStringAtPosition(
             $content,
             $offset,
-            implode("\n", $insert) . "\n"
+            "\n" . implode("\n", $insert) . "\n"
         );
         file_put_contents($projectDir . '/config/packages/twig.yaml', $content);
 


### PR DESCRIPTION
After changing the twig config, our first added line is on the same line as `twig:` which breaks the yaml config