### PR TITLE
Refactor IgnorePlugin to Webpack 5 syntax

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -205,7 +205,10 @@ class PostCreateProject
 
         $io->notice('→ add IgnorePlugin configuration');
         $insert = [
-            '.addPlugin(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/))',
+            '.addPlugin(new webpack.IgnorePlugin({',
+            '   resourceRegExp: /^\.\/locale$/,',
+            '   contextRegExp: /moment$/,',
+            '}))',
         ];
         $content = self::insertStringAtPosition(
             $content,


### PR DESCRIPTION
Error from `npm install` during initial composer create-project.
```
[webpack-cli] Invalid options object. Ignore Plugin has been initialized using an options object that does not match the API schema.
 - options should be one of these:
   object { resourceRegExp, contextRegExp? } | object { checkResource }
   Details:
    * options misses the property 'resourceRegExp'. Should be:
      RegExp
      -> A RegExp to test the request against.
    * options misses the property 'checkResource'. Should be:
      function
      -> A filter function for resource and context.
```
Fix from docs:
```
new webpack.IgnorePlugin({resourceRegExp, contextRegExp});
// old way, deprecated in webpack v5
new webpack.IgnorePlugin(resourceRegExp, [contextRegExp]);
```
Exact match with new syntax from Webpack 5 docs:
```
new webpack.IgnorePlugin({
  resourceRegExp: /^\.\/locale$/,
  contextRegExp: /moment$/,
});
```