### PR TITLE
Add the src folder to the Stylelint ignore

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -6,6 +6,7 @@ public/bundles/*
 public/files/*
 node_modules/*
 var/*
+src/*
 vendor/*
 **/*.dist
 **/*.json


### PR DESCRIPTION
In new framework projects there shouldn't be any CSS/Sass outside of the assets
and/or public/build folder. Right now Stylelint will also run on all of our PHP files.