### PR TITLE
Lock ChromeDriver to v97

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,7 +217,7 @@ PHPUnit - Run tests:
     - apt-get --allow-releaseinfo-change update && apt-get install -y chromium
     # install Chromium Chromedriver
     - |
-      curl -s -f -L -o /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_90`/chromedriver_linux64.zip
+      curl -s -f -L -o /tmp/chromedriver.zip http://chromedriver.storage.googleapis.com/`curl -sS chromedriver.storage.googleapis.com/LATEST_RELEASE_97`/chromedriver_linux64.zip
       unzip /tmp/chromedriver.zip chromedriver -d /usr/local/bin/
     # disable Xdebug and Blackfire extensions
     - |


### PR DESCRIPTION
Chromium on Debian is only at v97, Google Driver release is at 98