### PR TITLE
Allow some plugins to execute code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,11 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "symfony/flex": true,
+            "symfony/runtime": true
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Starting from  July 2022 unlisted plugins will not be able to execute code.
See https://getcomposer.org/doc/06-config.md#allow-plugins for more information