### PR TITLE
Limit the number of releases that should be kept to 3

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -74,6 +74,10 @@ set('bin/composer', function () {
     return '{{bin/php}} {{shared_folder}}/composer.phar';
 });
 
+// Limit the number of releases that should be kept
+set('keep_releases', 3);
+
+
 /*****************
  * Task sections *
  *****************/


### PR DESCRIPTION
Till this point the default of 10 was used, which is a bit much and unneeded.