### PR TITLE
Bump symfony/flex to the 2.0 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "ext-sodium": "*",
-        "symfony/flex": "^1.6.2"
+        "symfony/flex": "^2"
     },
     "flex-require": {
         "beberlei/doctrineextensions": "^1.3",

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "phpstan/phpstan-symfony": "^1.0",
         "squizlabs/php_codesniffer": "^3.4",
         "symfony/debug-pack": "*",
-        "symfony/phpunit-bridge": "^5.2",
+        "symfony/phpunit-bridge": "^6.1",
         "tijsverkoyen/deployer-sumo": "^2.0"
     },
     "config": {


### PR DESCRIPTION
We're on PHP8.1, so we should use the matching Flex version