### PR TITLE
Change the indentation of the sentry.yaml configuration file

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -445,9 +445,9 @@ class PostCreateProject
         $io->notice('→ Reconfigure sentry');
         $content = file_get_contents($projectDir . '/config/packages/sentry.yaml');
         $insert = [
-            '    options:',
-            '        integrations:',
-            '            - \'Sentry\Integration\IgnoreErrorsIntegration\'',
+            '       options:',
+            '           integrations:',
+            '               - \'Sentry\Integration\IgnoreErrorsIntegration\'',
             '',
             'services:',
             '    Sentry\Integration\IgnoreErrorsIntegration:',


### PR DESCRIPTION
As of Symfony 6, there is a when@prod prefix in the default sentry.yaml file that Symfony generates. To accommodate this, we have to add another tab to the indentation of our custom Sentry config.