### PR TITLE
Bump minimum dependency stability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "sumocoders/framework",
     "type": "project",
     "license": "proprietary",
-    "minimum-stability": "beta",
     "require": {
         "php": "^8.1",
         "ext-ctype": "*",


### PR DESCRIPTION
We had to set this to beta for the Deployer 7 beta, but this is no longer valid