### PR TITLE
Remove the public folder from the Twig path

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -368,9 +368,6 @@ class PostCreateProject
             '        - "@SumoCodersFrameworkCore/Form/fields.html.twig"',
             '        - "blocks.html.twig"',
             '    paths:',
-            '        # Add the public folder to the default twig path so we can access the',
-            '        # mail stylesheet through the inline_css method in the base email template.',
-            '        \'%kernel.project_dir%/public/\': ~',
         ];
         $content = self::insertStringAtPosition(
             $content,

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -367,7 +367,6 @@ class PostCreateProject
             '        - "bootstrap_5_layout.html.twig"',
             '        - "@SumoCodersFrameworkCore/Form/fields.html.twig"',
             '        - "blocks.html.twig"',
-            '    paths:',
         ];
         $content = self::insertStringAtPosition(
             $content,


### PR DESCRIPTION
We added a custom `content()` Twig extension in the core bundle to handle this (and fix a bug with twig caching our assets). This config is no longer necessary.

To be merged with https://github.com/sumocoders/FrameworkCoreBundle/pull/119