### PR TITLE
Do not send sentry traces to third-parties

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -440,6 +440,7 @@ class PostCreateProject
         $content = file_get_contents($projectDir . '/config/packages/sentry.yaml');
         $insert = [
             '        options:',
+            '           trace_propagation_targets: [ \'%env(resolve:DEFAULT_URI)%\' ]',
             '           integrations:',
             '               - \'Sentry\Integration\IgnoreErrorsIntegration\'',
             '',


### PR DESCRIPTION
Sending the baggage header might result in errors from external APIs and can potentially leak private data.

This limits the trace_propagation_targets to only the current domain. An empty array (the default when not set) is treated as all hosts are allow listed.

See this PR for additional info: https://github.com/getsentry/sentry-php/pull/1396