### PR TITLE
Composer audit

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -202,6 +202,16 @@ PHP packages - local-security-checker:
     - docker
   allow_failure: true
 
+PHP packages - composer audit:
+  image: sumocoders/cli-tools-php82:latest
+  script:
+    - composer audit --no-interaction
+  stage: dependency scanning
+  needs: ["Install dependencies and build assets"]
+  tags:
+    - docker
+  allow_failure: true
+
 
 # Test section
 PHPUnit - Run tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -181,7 +181,7 @@ NPM packages - check for vulnerabilities:
     - docker
   allow_failure: true
 
-PHP packages - check for vulnerabilities:
+PHP packages - local-security-checker:
   image: sumocoders/cli-tools-php82:latest
   before_script:
     - PHP_SC_VERSION=$(curl -s "https://api.github.com/repos/fabpot/local-php-security-checker/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/;s/^v//')


### PR DESCRIPTION
Add `composer audit` into our jobs.

<strike>I don't think it has a huge advantage over the `local-security-checker`</strike>. But it can't hurt to have it run also.
After reading some more it seems that `composer audit` use the same "database" as `local-security-checker`, but the GitHub advisory database also.

More information: https://php.watch/articles/composer-audit