### PR TITLE
Fix local security checker download url

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,7 +142,7 @@ PHP packages - local-php-security-checker:
   image: sumocoders/cli-tools-php82:latest
   before_script:
     - PHP_SC_VERSION=$(curl -s "https://api.github.com/repos/fabpot/local-php-security-checker/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/;s/^v//')
-    - curl -LSs https://github.com/fabpot/local-php-security-checker/releases/download/v${PHP_SC_VERSION}/local-php-security-checker_${PHP_SC_VERSION}_linux_amd64 > ./local-php-security-checker
+    - curl -LSs https://github.com/fabpot/local-php-security-checker/releases/download/v${PHP_SC_VERSION}/local-php-security-checker_linux_amd64 > ./local-php-security-checker
     - chmod +x ./local-php-security-checker
   script:
     - ./local-php-security-checker --format=ansi


### PR DESCRIPTION
Since version 2.1.0 of local-php-security-checker, the name of the prebuild binary changed (https://github.com/fabpot/local-php-security-checker/releases).