### PR TITLE
332 docker config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,5 +6,7 @@ services:
     ports:
       - 3306:3306
     restart: always
+    labels:
+      com.symfony.server.service-ignore: true
     volumes:
       - ~/Sites/sumocoders/docker/mariadb:/var/lib/mysql

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -586,6 +586,18 @@ class PostCreateProject
             '',
             $content
         );
+        // remove symfony/mailer configuration
+        $content = preg_replace(
+            '|###> symfony/mailer ###.*###< symfony/mailer ###|mUs',
+            '',
+            $content
+        );
+        // remove empty volumes element
+        $content = preg_replace(
+            '|services:\n|mUs',
+            '',
+            $content
+        );
         $content = trim($content) . PHP_EOL;
         file_put_contents($projectDir . '/docker-compose.override.yml', $content);
     }

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -560,6 +560,23 @@ class PostCreateProject
             PHP_EOL . implode(PHP_EOL, $insert)
         );
         file_put_contents($projectDir . '/.env', $content);
+
+        $io->notice('→ Reconfigure docker-compose.yml');
+        $content = file_get_contents($projectDir . '/docker-compose.yml');
+        // remove doctrine/doctrine-bundle configuration
+        $content = preg_replace(
+            '|###> doctrine/doctrine-bundle ###.*###< doctrine/doctrine-bundle ###|mUs',
+            '',
+            $content
+        );
+        // remove empty volumes element
+        $content = preg_replace(
+            '|volumes:\n\n|mUs',
+            '',
+            $content
+        );
+        $content = trim($content) . PHP_EOL;
+        file_put_contents($projectDir . '/docker-compose.yml', $content);
     }
 
     private static function cleanup(Event $event): void

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -577,6 +577,17 @@ class PostCreateProject
         );
         $content = trim($content) . PHP_EOL;
         file_put_contents($projectDir . '/docker-compose.yml', $content);
+
+        $io->notice('→ Reconfigure docker-compose.override.yml');
+        $content = file_get_contents($projectDir . '/docker-compose.override.yml');
+        // remove doctrine/doctrine-bundle configuration
+        $content = preg_replace(
+            '|###> doctrine/doctrine-bundle ###.*###< doctrine/doctrine-bundle ###|mUs',
+            '',
+            $content
+        );
+        $content = trim($content) . PHP_EOL;
+        file_put_contents($projectDir . '/docker-compose.override.yml', $content);
     }
 
     private static function cleanup(Event $event): void


### PR DESCRIPTION
https://app.activecollab.com/108877/my-work?modal=Task-208182-533

Don't expose Symfony Server magic ENV variables into our database service.
Remove `doctrine/doctrine-bundle` and `symfony/mailer` docker stuff that may be added automatically.