### PR TITLE
318: Symfony 7.1 - Allowed recipients

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -282,6 +282,21 @@ EOF;
         );
         file_put_contents($projectDir . '/config/packages/messenger.yaml', $content);
 
+        $io->notice('→ Reconfigure mailer');
+        file_put_contents($projectDir . '/config/packages/mailer.yaml',
+        <<<'EODEV'
+
+        when@dev:
+            framework:
+                mailer:
+                    envelope:
+                        # needs at least one recipient, otherwise allowed_recipients is ignored
+                        recipients: ['mail@localhost']
+                        allowed_recipients:
+                            - '.*@sumocoders.be'
+                            - '.*@tesuta.be'
+        EODEV, FILE_APPEND);
+
         $io->notice('→ Reconfigure .env');
         $content = file_get_contents($projectDir . '/.env');
         // Set the default env to prod


### PR DESCRIPTION
https://symfony.com/blog/new-in-symfony-7-1-misc-improvements#better-email-delivery-control

## Summary by Sourcery

Configure Symfony 7.1 mailer envelope in the skeleton with a default recipient and restricted allowed_recipients for the dev environment

Enhancements:
- Append mailer.yaml configuration to skeleton for dev environment envelope and allowed_recipients settings
- Add console notice for mailer reconfiguration in project post-create script