### PR TITLE
Update mysql in tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -170,7 +170,7 @@ PHP packages - composer outdated:
 PHPUnit - Run tests:
   image: sumocoders/framework-php84:latest
   services:
-    - mysql:5.7
+    - mysql:8.0
   before_script:
 # Uncomment this if you need Chrome for PDF's
 # or if you have integration tests that use Symfony Panther (https://github.com/symfony/panther)


### PR DESCRIPTION
Update mysql version in tests

## Summary by Sourcery

CI:
- Bump MySQL service to version 8.0 for PHPUnit CI jobs