### PR TITLE
Add job that will be used for scheduled tasks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - build
+  - scheduled tasks
   - code quality
   - dependency scanning
   - outdated packages
@@ -198,6 +199,23 @@ PHPUnit - Run tests:
     DATABASE_URL: mysql://root:root@mysql:3306/ci_test?serverVersion=5.7
     PANTHER_NO_SANDBOX: 1
     PANTHER_WEB_SERVER_PORT: 9080
+
+
+# Scheduled tasks section
+Task - Update dependencies:
+  image: sumocoders/cli-tools-php84:latest
+  script:
+    - git config --global user.email "bot@sumocoders.be"
+    - git config --global user.name "Sumo Bot"
+    - git config --global push.autoSetupRemote true
+    - git remote set-url origin "https://bot:${GITLAB_ACCESS_TOKEN}@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+    - php bin/console sumo:maintenance:create-pr-for-outdated-dependencies --no-interaction --ansi
+  stage: scheduled tasks
+  needs: [ "Install dependencies and build assets" ]
+  rules:
+    - if: '$CI_PIPELINE_SOURCE =~ /schedule|web/'
+  tags:
+    - docker
 
 
 # Deploy section

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "beberlei/doctrineextensions": "^1.5",
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "sentry/sentry-symfony": "^5.1",
-        "sumocoders/framework-core-bundle": "^14.0",
+        "sumocoders/framework-core-bundle": "^14.1",
         "symfony/apache-pack": "^1.0.1",
         "symfony/asset-mapper": "^7.2",
         "symfony/debug-bundle": "^7.2",


### PR DESCRIPTION
https://next-app.activecollab.com/108877/my-work?modal=Task-230709-533

## Summary by Sourcery

Add a new CI stage for scheduled tasks and configure a job that runs on scheduled or manual triggers to update dependencies by creating automated PRs

New Features:
- Added a 'scheduled tasks' stage to the GitLab CI pipeline
- Introduced a CI job to automatically create pull requests for outdated dependencies on a schedule