### PR TITLE
feat: Use dev03 instead of dev02

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ automatically. To do so, follow the steps below:
    under "Sumo Deploy User private key". You can check the "Protect variable" 
    flag.
 5. Add a variable called `SSH_KNOWN_HOSTS`, the value should be the output of 
-    `ssh-keyscan -H dev02.sumocoders.eu`.
+    `ssh-keyscan -H dev03.sumocoders.eu`.
 6. Open `.gitlab-ci.yaml`, scroll to `Deploy - to staging`.
 7. Alter the url under `environment → url`.
     

--- a/deploy.php
+++ b/deploy.php
@@ -15,7 +15,7 @@ set('production_user', '$productionUser');
 set('php_version', '8.4');
 
 // Define staging
-host('dev02.sumocoders.eu')
+host('dev03.sumocoders.eu')
     ->setRemoteUser('sites')
     ->set('labels', ['stage' => 'staging'])
     ->set('deploy_path', '~/apps/{{client}}/{{project}}')


### PR DESCRIPTION
https://next-app.activecollab.com/108877/my-work?modal=Task-234790-533

## Summary by Sourcery

Switch staging environment host from dev02.sumocoders.eu to dev03.sumocoders.eu in deployment configuration and documentation

Deployment:
- Update deploy.php to target host dev03.sumocoders.eu for staging

Documentation:
- Revise README instructions to use ssh-keyscan on dev03.sumocoders.eu for SSH_KNOWN_HOSTS