### PR TITLE
chore: Upgrade tp PHP CodeSniffer 4.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,7 +37,7 @@ Install dependencies and build assets:
 PHP_CodeSniffer - check code styling:
   image: sumocoders/cli-tools-php84:latest
   script:
-    - php vendor/bin/phpcs --report-full --report-\\Micheh\\PhpCodeSniffer\\Report\\Gitlab=phpcs-report.json
+    - php vendor/bin/phpcs --colors --report-full --report-\\Micheh\\PhpCodeSniffer\\Report\\Gitlab=phpcs-report.json
   artifacts:
     expire_in: 1 week
     reports:

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpstan/phpstan-symfony": "^2.0",
         "phpstan/phpstan-doctrine": "^2.0",
         "phpunit/phpunit": "^12.2",
-        "squizlabs/php_codesniffer": "^3.11",
+        "squizlabs/php_codesniffer": "^4.0",
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "*",
         "symfony/stopwatch": "^7.3",


### PR DESCRIPTION
## Summary by Sourcery

Upgrade PHP_CodeSniffer to 4.0 and enhance CI configuration to display colored linting reports

Enhancements:
- Enable colored output for PHP_CodeSniffer reports in CI

Build:
- Bump PHP_CodeSniffer dependency to version ^4.0

CI:
- Update GitLab CI phpcs command to include --colors flag