### PR TITLE
Fix phpunit in gitlab ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,7 @@ cache: &global_cache
     - node_modules
     - public/build
     - vendor
+    - var/sass
   policy: pull
 
 


### PR DESCRIPTION
Cache output from sass build. Needed for some phpunit tests from https://github.com/sumocoders/Framework-User-Implementation-Example.

## Summary by Sourcery

CI:
- Cache the var/sass directory in GitLab CI to make assets available for PHPUnit tests.