### PR TITLE
423 Cache headers

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -640,16 +640,6 @@ class PostCreateProject
         $io->notice('→ Reconfigure .htaccess');
         file_put_contents($projectDir . '/public/.htaccess', <<<'EOF'
 
-            <IfModule !mod_rewrite.c>
-                <IfModule mod_alias.c>
-                    # When mod_rewrite is not available, we instruct a temporary redirect of
-                    # the start page to the front controller explicitly so that the website
-                    # and the generated links can still be used.
-                    RedirectMatch 307 ^/$ /index.php/
-                    # RedirectTemp cannot be used instead
-                </IfModule>
-            </IfModule>
-
             # file caching in browser
             <IfModule mod_expires.c>
                 ExpiresActive On

--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -62,6 +62,7 @@ class PostCreateProject
         self::reconfigureEnv($event);
         self::reconfigureDockerCompose($event);
         self::reconfigureNelmioSecurityBundle($event);
+        self::reconfigureApachePack($event);
     }
 
     private static function reconfigureSymfonycastsSass(Event $event): void
@@ -629,6 +630,47 @@ class PostCreateProject
 
             EOF;
         file_put_contents($projectDir . '/config/packages/nelmio_security.yaml', $content);
+    }
+
+    private static function reconfigureApachePack(Event $event): void
+    {
+        $io = $event->getIO();
+        $projectDir = self::getProjectDir($event);
+
+        $io->notice('→ Reconfigure .htaccess');
+        file_put_contents($projectDir . '/public/.htaccess', <<<'EOF'
+
+            <IfModule !mod_rewrite.c>
+                <IfModule mod_alias.c>
+                    # When mod_rewrite is not available, we instruct a temporary redirect of
+                    # the start page to the front controller explicitly so that the website
+                    # and the generated links can still be used.
+                    RedirectMatch 307 ^/$ /index.php/
+                    # RedirectTemp cannot be used instead
+                </IfModule>
+            </IfModule>
+
+            # file caching in browser
+            <IfModule mod_expires.c>
+                ExpiresActive On
+                <FilesMatch "\.(?i:ico|gif|jpe?g|png|svg|svgz|js|css|swf|ttf|otf|woff|woff2|eot)$">
+                    ExpiresDefault "access plus 1 year"
+                </FilesMatch>
+            </IfModule>
+
+            # gzip on Apache 2
+            <IfModule mod_deflate.c>
+                AddOutputFilterByType DEFLATE text/html text/plain text/xml application/xml text/javascript text/css application/x-javascript application/xhtml+xml application/javascript application/json image/svg+xml
+
+                # these browsers do not support deflate
+                BrowserMatch ^Mozilla/4 gzip-only-text/html
+                BrowserMatch ^Mozilla/4.0[678] no-gzip
+                BrowserMatch bMSIE !no-gzip !gzip-only-text/html
+
+                SetEnvIf User-Agent ".*MSIE.*" nokeepalive ssl-unclean-shutdown downgrade-1.0 force
+            </IfModule>
+
+            EOF, FILE_APPEND);
     }
 
     private static function fixFiles(Event $event): void


### PR DESCRIPTION
Add cache headers to .htaccess

## Summary by Sourcery

Introduce Apache .htaccess reconfiguration during project setup to add caching and compression directives for static and text-based assets.

New Features:
- Add automated reconfiguration of the public .htaccess file for Apache-based deployments.

Enhancements:
- Configure browser caching headers for static assets via Apache Expires directives.
- Enable gzip compression for common text and SVG responses via Apache deflate configuration.