### PR TITLE
Fix framework.router.default_uri with Symfony CLI

### DIFF
--- a/src/Skeleton/PostCreateProject.php
+++ b/src/Skeleton/PostCreateProject.php
@@ -200,15 +200,18 @@ class PostCreateProject
         $projectDir = self::getProjectDir($event);
 
         $io->notice('→ Reconfigure routing');
-        $content = file_get_contents($projectDir . '/config/packages/routing.yaml');
-        if ($content !== false) {
-            $content = preg_replace(
-                '/#default_uri: http:\/\/localhost/smU',
-                'default_uri: \'%env(DEFAULT_URI)%\'',
-                $content,
-            );
-            file_put_contents($projectDir . '/config/packages/routing.yaml', $content);
-        }
+        // Because when using Symfony CLI server:
+        // - the DEFAULT_URI for CLI usage will be set to https://127.0.0.1:8000/
+        // - for web usage this will also be the case, unless you use a proxy, then that value will be used
+        // You can't overwrite it with a env-variable in .env or .env.local, so for local development
+        // we will use a separate env-variable, DEFAULT_URL
+        file_put_contents($projectDir . '/config/packages/routing.yaml', <<<'EOF'
+
+            when@dev:
+                framework:
+                    router:
+                        default_uri: '%env(DEFAULT_URL)%'
+            EOF, FILE_APPEND);
     }
 
     private static function reconfigureFramework(Event $event): void
@@ -453,7 +456,7 @@ class PostCreateProject
                 '###> sumocoders/framework-core-bundle ###',
                 'SITE_TITLE="Your application"',
                 'ENCRYPTION_KEY="' . $encryptionKey . '"',
-                'DEFAULT_URI="/"',
+                'DEFAULT_URL="/"',
                 '###< sumocoders/framework-core-bundle ###',
             ];
             $content = self::insertStringAtPosition(


### PR DESCRIPTION
The symfony/routing recipe now ships default_uri uncommented and adds DEFAULT_URI to .env by default, making the old reconfigureRouting() replacement and DEFAULT_URI insertion redundant. 

Add a when@dev override using a new DEFAULT_URL env var instead, so it won't be overridden by the Symfony CLI setup.

## Summary by Sourcery

Adjust routing configuration to use a separate DEFAULT_URL for local development when using Symfony CLI.

Bug Fixes:
- Prevent Symfony CLI from overriding the framework.router.default_uri used in local development.

Enhancements:
- Configure a when@dev router.default_uri override that reads from a dedicated DEFAULT_URL environment variable instead of DEFAULT_URI.
- Update the project skeleton to define DEFAULT_URL in .env for development-specific routing configuration.